### PR TITLE
Fix sign mismatch in `valueToString`

### DIFF
--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -125,7 +125,7 @@ JSONCPP_STRING valueToString(double value, bool useSpecialFloats, unsigned int p
   int len = -1;
 
   char formatString[15];
-  snprintf(formatString, sizeof(formatString), "%%.%dg", precision);
+  snprintf(formatString, sizeof(formatString), "%%.%ug", precision);
 
   // Print into the buffer. We need not request the alternative representation
   // that always has a decimal point because JSON doesn't distinguish the


### PR DESCRIPTION
`valueToString` takes an argument `unsigned int precision`, but it is used with `%d` rather than `%u` in the `snprintf` format string. Make the format string look for an unsigned value instead.